### PR TITLE
Change package from python-pyopenssl to python-openssl to fix 'package not found' error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /SABnzbd
 RUN python tools/make_mo.py
 
 # optional dependencies
-RUN apt-get -y install unrar-free unzip par2 python-pyopenssl
+RUN apt-get -y install unrar-free unzip par2 python-openssl
 
 # Clean up APT when done.
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
When trying to run your version I was receiving the error: 

`E: Unable to locate package python-pyopenssl`

`apt-get update` is performed at a previous step so I can only assume that the package name has now changed as it's been a while since the last commit here. Changing to this does indeed work for me but maybe I am doing something wrong in which case, reject this PR.

Thanks for your efforts :)

Rod